### PR TITLE
[#9] feat: 테이블 컴포넌트 뼈대

### DIFF
--- a/client/src/Components/Table/Table.stories.tsx
+++ b/client/src/Components/Table/Table.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Table from '.';
+
+export default {
+  title: '컴포넌트/헤더',
+  component: Table,
+} as ComponentMeta<typeof Table>;
+
+const Template: ComponentStory<typeof Table> = () => (
+  <Table headers={[]} items={[]} />
+);
+
+export const Default = Template.bind({});

--- a/client/src/Components/Table/Table.tsx
+++ b/client/src/Components/Table/Table.tsx
@@ -2,13 +2,11 @@ import React from 'react';
 import * as S from './styles';
 
 interface ITableProps {
-  headers: Iheader[];
+  headers: {
+    name: string;
+    value: string;
+  }[];
   items: Record<string, string | number>[];
-}
-
-interface Iheader {
-  name: string;
-  value: string;
 }
 
 const Table = ({ headers, items }: ITableProps) => {

--- a/client/src/Components/Table/Table.tsx
+++ b/client/src/Components/Table/Table.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import * as S from './styles';
+
+interface ITableProps {
+  headers: Iheader[];
+  items: Record<string, string | number>[];
+}
+
+interface Iheader {
+  name: string;
+  value: string;
+}
+
+const Table = ({ headers, items }: ITableProps) => {
+  return (
+    <S.Table>
+      <thead>
+        <S.TableRow className="table-header">
+          {headers.map((col) => (
+            <S.TableHeader key={col.value}>{col.name}</S.TableHeader>
+          ))}
+        </S.TableRow>
+      </thead>
+
+      <tbody>
+        {items.map((item) => (
+          <S.TableRow key={item.id}>
+            {headers.map((col) => (
+              <S.TableData key={col.value}>{item[col.value]}</S.TableData>
+            ))}
+          </S.TableRow>
+        ))}
+      </tbody>
+    </S.Table>
+  );
+};
+
+export default Table;

--- a/client/src/Components/Table/index.tsx
+++ b/client/src/Components/Table/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Table';

--- a/client/src/Components/Table/styles.ts
+++ b/client/src/Components/Table/styles.ts
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+export const Table = styled.table`
+  width: 90%;
+  margin: 120px auto;
+  border-radius: 0.4em;
+  overflow: hidden;
+  ${({ theme }) => theme.fontSize.s};
+  ${({ theme }) => theme.fontWeight.s};
+  border-collapse: collapse;
+  font-size: 1rem;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
+`;
+
+export const TableRow = styled.tr`
+  &.table-header {
+    color: ${({ theme }) => theme.color['off-white']};
+    background-color: ${({ theme }) => theme.color.primary};
+  }
+  height: 60px;
+  border-bottom: 1px solid ${({ theme }) => theme.color.line};
+  &:last-child {
+    border-bottom: 2px solid ${({ theme }) => theme.color.primary};
+  }
+`;
+export const TableHeader = styled.th`
+  padding: 1.2rem;
+`;
+
+export const TableData = styled.td`
+  text-align: center;
+  padding: 1.2rem;
+  ${({ theme }) => theme.fontWeight.s};
+`;

--- a/client/src/dummies/table.js
+++ b/client/src/dummies/table.js
@@ -1,0 +1,38 @@
+const headers = [
+  { name: '날짜/주문번호', value: 'date' },
+  { name: '상품명', value: 'name' },
+  { name: '가격', value: 'price' },
+  { name: '수량', value: 'quantity' },
+  { name: '주문상태', value: 'status' },
+  { name: '확인/리뷰', value: 'review' },
+];
+
+const items = [
+  {
+    id: 1,
+    date: '2021.08.21',
+    name: '배민방구',
+    price: '2000원',
+    quantity: 4,
+    status: '구매 완료',
+    review: 'done',
+  },
+  {
+    id: 2,
+    date: '2021.08.19',
+    name: '배민방구',
+    price: '2000원',
+    quantity: 4,
+    status: '구매 완료',
+    review: 'done',
+  },
+  {
+    id: 3,
+    date: '2021.08.14',
+    name: '배민방구',
+    price: '2000원',
+    quantity: 4,
+    status: '구매 완료',
+    review: 'done',
+  },
+];

--- a/client/src/styles/globalStyle.ts
+++ b/client/src/styles/globalStyle.ts
@@ -21,6 +21,10 @@ const GlobalStyle = createGlobalStyle`
     font-family: 'Noto Sans KR', sans-serif;
   }
 
+  * {
+    box-sizing: border-box;
+  }
+
   a {
     text-decoration: none;
     color: inherit;


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->
테이블 컴포넌트 기본 뼈대를 추가합니다.

## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 ex. #10 -->

closes #9 

## 추가 구현 필요사항
- 이게 단순 텍스트가 아니라 다양한 타입을 받게 될 수 있을 거 같아요 (주문 내역에서 내 리뷰 보러가기, 상품 보러가기 등의 기능) 아직  테이블이 어디에서 어떻게 쓰일지 명확하지 않아서, 기본 뼈대만 작성했습니다 😢 

- 아마 스타일도 다시 들어가야겠죠...?
## 스크린샷
<img width="1069" alt="스크린샷 2021-08-11 오후 10 33 56" src="https://user-images.githubusercontent.com/21697238/129040814-1ce434c1-fe3c-4f47-b1c0-ab5ea2604de2.png">
