### PR TITLE
탭 공통 컴포넌트 작성

### DIFF
--- a/client/src/components/Modal/index.tsx
+++ b/client/src/components/Modal/index.tsx
@@ -1,0 +1,3 @@
+import PolicyModal from './PolicyModal';
+
+export { PolicyModal };

--- a/client/src/components/Tab/TabExample.stories.tsx
+++ b/client/src/components/Tab/TabExample.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import TabExample from './TabExample';
+
+export default {
+  title: '컴포넌트/탭예시(1)',
+  component: TabExample,
+} as ComponentMeta<typeof TabExample>;
+
+const Template: ComponentStory<typeof TabExample> = () => <TabExample />;
+
+export const Default = Template.bind({});

--- a/client/src/components/Tab/TabExample.tsx
+++ b/client/src/components/Tab/TabExample.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { TabWrapper, Tabs, TabPanel, Tab } from './TabUI';
+import Banner from '@/components/Banner/';
+
+const TabExample = () => {
+  return (
+    <TabWrapper>
+      <Tabs>
+        <Tab label="탭1" index={0} />
+        <Tab label="탭2" index={1} />
+        <Tab label="탭3" index={2} />
+      </Tabs>
+      <TabPanel index={0}>탭탭탭1</TabPanel>
+      <TabPanel index={1}>
+        <Banner />
+      </TabPanel>
+      <TabPanel index={2}>탭탭탭3</TabPanel>
+    </TabWrapper>
+  );
+};
+
+export default TabExample;

--- a/client/src/components/Tab/TabExample2.tsx
+++ b/client/src/components/Tab/TabExample2.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { TabWrapper, Tabs, TabPanel, Tab } from './TabUI';
+import NotFound from '@/components/NotFound';
+
+const TabExample2 = () => {
+  return (
+    <TabWrapper>
+      <Tabs>
+        <Tab label="이것은탭이다(1)!" index={0} />
+        <Tab label="이것은탭이다(2)!" index={1} />
+        <Tab label="이것은탭이다(3)!" index={2} />
+      </Tabs>
+      <TabPanel index={0}>This is Tab1</TabPanel>
+      <TabPanel index={1}>This is Tab2</TabPanel>
+      <TabPanel index={2}>
+        <NotFound />
+      </TabPanel>
+    </TabWrapper>
+  );
+};
+
+export default TabExample2;

--- a/client/src/components/Tab/TabUI/Tab.tsx
+++ b/client/src/components/Tab/TabUI/Tab.tsx
@@ -1,0 +1,28 @@
+import React, { useContext } from 'react';
+import * as S from './styles';
+import { Context } from './TabContext';
+
+interface TabProps {
+  label: string;
+  index: number;
+}
+
+const Tab = ({ label, index }: TabProps) => {
+  const { value, setValue } = useContext(Context);
+
+  const handleClick = () => {
+    setValue(index);
+  };
+
+  return (
+    <S.TabTitle
+      className={value === index ? 'active' : ''}
+      onClick={handleClick}
+      data-index={index}
+    >
+      {label}
+    </S.TabTitle>
+  );
+};
+
+export default Tab;

--- a/client/src/components/Tab/TabUI/TabContext.tsx
+++ b/client/src/components/Tab/TabUI/TabContext.tsx
@@ -1,0 +1,34 @@
+import React, {
+  createContext,
+  Dispatch,
+  SetStateAction,
+  useState,
+  VFC,
+} from 'react';
+import * as S from './styles';
+
+interface ContextProps {
+  value: number;
+  setValue: Dispatch<SetStateAction<number>>;
+}
+
+export interface TabContextProps {
+  children?: React.ReactNode;
+}
+
+export const Context = createContext<ContextProps>({
+  value: 0,
+  setValue: () => {},
+});
+
+const TabContext: VFC<TabContextProps> = ({ children }) => {
+  const [value, setValue] = useState(0);
+
+  return (
+    <Context.Provider value={{ value, setValue }}>
+      <S.Tab>{children}</S.Tab>
+    </Context.Provider>
+  );
+};
+
+export default TabContext;

--- a/client/src/components/Tab/TabUI/TabPanel.tsx
+++ b/client/src/components/Tab/TabUI/TabPanel.tsx
@@ -1,0 +1,20 @@
+import React, { useContext, VFC } from 'react';
+import * as S from './styles';
+import { Context } from './TabContext';
+
+interface TabPanelProps {
+  children: React.ReactNode;
+  index: number;
+}
+
+const TabPanel: VFC<TabPanelProps> = ({ children, index }) => {
+  const { value } = useContext(Context);
+
+  return (
+    <S.TabPanel className={value === index ? 'active' : ''} data-index={index}>
+      {children}
+    </S.TabPanel>
+  );
+};
+
+export default TabPanel;

--- a/client/src/components/Tab/TabUI/Tabs.tsx
+++ b/client/src/components/Tab/TabUI/Tabs.tsx
@@ -1,0 +1,9 @@
+import React, { useContext, VFC } from 'react';
+import TabContext, { Context, TabContextProps } from './TabContext';
+import * as S from './styles';
+
+const Tabs: VFC<TabContextProps> = ({ children }) => {
+  return <S.TabTitleArea>{children}</S.TabTitleArea>;
+};
+
+export default Tabs;

--- a/client/src/components/Tab/TabUI/index.tsx
+++ b/client/src/components/Tab/TabUI/index.tsx
@@ -1,0 +1,6 @@
+import Tabs from './Tabs';
+import Tab from './Tab';
+import TabPanel from './TabPanel';
+import TabWrapper from './TabContext';
+
+export { Tabs, Tab, TabPanel, TabWrapper };

--- a/client/src/components/Tab/TabUI/styles.ts
+++ b/client/src/components/Tab/TabUI/styles.ts
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+
+export const Tab = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const TabTitleArea = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const TabTitle = styled.span`
+  ${({ theme }) => theme.fontSize.m};
+  ${({ theme }) => theme.fontWeight.m};
+  width: 100%;
+  padding: 1.5rem;
+  border: 1px solid #ededed;
+  user-select: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in;
+
+  &.active {
+    color: #fff;
+    background-color: ${({ theme }) => theme.color.primary};
+  }
+`;
+
+export const TabPanel = styled.div`
+  display: none;
+  ${({ theme }) => theme.fontSize.m}
+  ${({ theme }) => theme.fontWeight.s}
+
+  &.active {
+    display: block;
+  }
+`;

--- a/client/src/components/Tab/index.tsx
+++ b/client/src/components/Tab/index.tsx
@@ -1,0 +1,4 @@
+import TabExample from './TabExample';
+import TabExample2 from './TabExample2';
+
+export { TabExample, TabExample2 };

--- a/client/src/pages/Detail/Detail.tsx
+++ b/client/src/pages/Detail/Detail.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as S from './styles';
 import { StationerySVG as Stationery } from '@/assets/svgs';
 import { useParams } from '@/core/Router';
+import { TabExample, TabExample2 } from '@/components/Tab';
 
 const Detail = () => {
   const { params } = useParams();
@@ -11,6 +12,10 @@ const Detail = () => {
     <S.Detail>
       <h1>이곳은 디테일 페이지 영역 #{params.id}</h1>
       <p>안녕하세요 디테일 입니다</p>
+
+      <TabExample />
+      <TabExample2 />
+
       <Stationery />
     </S.Detail>
   );

--- a/client/src/pages/Main/Main.tsx
+++ b/client/src/pages/Main/Main.tsx
@@ -3,7 +3,8 @@ import * as S from './styles';
 import Card from '@/components/Card';
 import CardWrapper from '@/components/CardWrapper';
 import Banner from '@/components/Banner';
-import PolicyModal from '@/components/Modal/PolicyModal';
+import { PolicyModal } from '@/components/Modal';
+import { TabExample } from '@/components/Tab';
 
 const Main = () => {
   const [isOpen, setOpen] = useState(false);
@@ -31,6 +32,8 @@ const Main = () => {
           <Card bgColor="error" discount={25} />
           <Card bgColor="error" />
         </CardWrapper>
+
+        <TabExample />
 
         {isOpen && <PolicyModal toggleModal={toggleModal} />}
       </S.Main>


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->

- Context API를 사용해서 공통 Tab UI 컴포넌트 작성
- 모달(Modal)과 비슷한 방식으로 폴더 구조화
- 메인페이지(`/main`)와 디테일페이지(`/detail/:id`)에서 탭 UI 확인 가능

## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 ex. #10 -->

closes #64 

## 추가 구현 필요사항

- 디자인은 당연히 다듬어야 할 거 같습니다. 저는 더 이상 디자인에 메달리지 않기로 했거등요 호호호~ 그래서 지금 디자인은 아주 단순한 형태입니다
- 관심있다면 loadable을 이용한 최적화 렌더링을 알아보십쇼 호호호~  하지만 이 구조엔 라우팅 형식이 아니라 적용하긴 힘들겝니다(?)
- 예시파일 1번 2번 작성했습니다~ 어차피 예시라서 스토리북 코드는 1번 예시파일만 작성했습니다~
- 사용방법은 따로 간단하게 문서화 하게씁니다~

## 스크린샷

- Storybook 리뷰/테스트 참고
