### PR TITLE
찜 메인페이지 및 카드 컴포넌트 연동

### DIFF
--- a/client/src/components/Card/Card.tsx
+++ b/client/src/components/Card/Card.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/assets/svgs';
 import { Link } from '@/lib/Router';
 import wonFormat from '@/utils/wonFormat';
+import { useAddBookmark, useDeleteBookmark } from '@/hooks/queries/bookmark';
 
 interface CardProps {
   bgColor: 'error' | 'primary'; // category 식으로 리스트화 (enum 등..) 필요
@@ -18,6 +19,7 @@ interface CardProps {
   checkBoxDisplay?: boolean;
   setCheckedList?: Dispatch<number[]>;
   checkedList?: number[];
+  bookmarkList?: number[];
 }
 
 const Card = ({
@@ -31,7 +33,11 @@ const Card = ({
   checkBoxDisplay = false,
   setCheckedList,
   checkedList,
+  bookmarkList,
 }: CardProps) => {
+  const { mutate: addMutate } = useAddBookmark();
+  const { mutate: deleteMutate } = useDeleteBookmark();
+
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
@@ -48,9 +54,21 @@ const Card = ({
     }
   };
 
+  const isHeartChecked = !!bookmarkList?.find(
+    (checkedId) => checkedId === linkId
+  );
+
   const checkBoxOnClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
   }, []);
+
+  const heartBtnOnClick = useCallback(() => {
+    if (isHeartChecked) {
+      deleteMutate([linkId]);
+    } else {
+      addMutate(linkId);
+    }
+  }, [addMutate, deleteMutate, isHeartChecked, linkId]);
 
   return (
     <Link to={`/detail/${linkId}`}>
@@ -69,7 +87,12 @@ const Card = ({
           {!bottomDisplay || (
             <S.BottomBar onClick={handleClick}>
               <S.ButtonArea>
-                <HeartButton witdh={24} height={24} />
+                <HeartButton
+                  witdh={24}
+                  height={24}
+                  fill={isHeartChecked ? 'red' : 'none'}
+                  onClick={heartBtnOnClick}
+                />
               </S.ButtonArea>
               <S.ButtonArea>
                 <ShoppingCart witdh={24} height={24} />

--- a/client/src/components/Card/Card.tsx
+++ b/client/src/components/Card/Card.tsx
@@ -41,7 +41,6 @@ const Card = ({
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
-    console.log('a 링크 이동 이벤트를 막자요');
   };
 
   const isChecked = !!checkedList?.find((checkedId) => checkedId === linkId);

--- a/client/src/components/Card/Card.tsx
+++ b/client/src/components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch } from 'react';
+import React, { Dispatch, useCallback } from 'react';
 import * as S from './styles';
 import {
   HeartSVG as HeartButton,
@@ -48,13 +48,21 @@ const Card = ({
     }
   };
 
+  const checkBoxOnClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+  }, []);
+
   return (
     <Link to={`/detail/${linkId}`}>
       <S.Card>
         <S.Liner bgColor={bgColor} />
         <S.ThumbnailWrapper>
           {!checkBoxDisplay || (
-            <S.CardCheckbox onChange={onChangeCheckbox} checked={isChecked} />
+            <S.CardCheckbox
+              onChange={onChangeCheckbox}
+              checked={isChecked}
+              onClick={checkBoxOnClick}
+            />
           )}
           {discount && <S.NameTag>{discount}%</S.NameTag>}
           <img src={src} alt="상품 섬네일 이미지" />

--- a/client/src/components/Shared/Button/Button.tsx
+++ b/client/src/components/Shared/Button/Button.tsx
@@ -22,11 +22,12 @@ const Button = ({
   disabled = false,
   className,
 }: IButtonProps) => {
+  const newClassName = className ? color + ' ' + className : color;
   return (
     <S.Button
       type={type}
       color={color}
-      className={color + ' ' + className}
+      className={newClassName}
       onClick={onClick}
       size={size}
       fullWidth={fullWidth}

--- a/client/src/components/Shared/Checkbox/Checkbox.tsx
+++ b/client/src/components/Shared/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { CheckSVG } from '@/assets/svgs';
 import * as S from './styles';
 

--- a/client/src/components/Shared/Checkbox/Checkbox.tsx
+++ b/client/src/components/Shared/Checkbox/Checkbox.tsx
@@ -9,6 +9,7 @@ interface IProps {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   className?: string;
   checked?: boolean;
+  onClick?: (e: React.MouseEvent) => void;
 }
 const Checkbox = ({
   label,
@@ -17,13 +18,10 @@ const Checkbox = ({
   className,
   checked,
   name,
+  onClick,
 }: IProps) => {
-  const checkBoxOnClick = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-  }, []);
-
   return (
-    <S.Checkbox className={className} onClick={checkBoxOnClick}>
+    <S.Checkbox className={className} onClick={onClick}>
       <input
         name={name}
         type="checkbox"

--- a/client/src/hooks/queries/bookmark/index.tsx
+++ b/client/src/hooks/queries/bookmark/index.tsx
@@ -1,25 +1,67 @@
 import { notify } from '@/components/Shared/Toastify';
+import { addBookmark } from '@/lib/api/bookmark/addBookmark';
 import { deleteBookmark } from '@/lib/api/bookmark/deleteBookmark';
+import { getBookmarkProducts } from '@/lib/api/bookmark/getBookmarkProducts';
 import { getDetailBookmarkProducts } from '@/lib/api/bookmark/getDetailBookmarkProducts';
 import { IBookmarkProduct } from '@/types';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 export const useGetDetailBookmarkProducts = () => {
   return useQuery<IBookmarkProduct[], Error>(
-    'bookmarkedProduct',
+    'detailBookmarkedProduct',
     getDetailBookmarkProducts
   );
+};
+
+export const useGetBookmarkIds = () => {
+  return useQuery<number[], Error>('bookmarkedProduct', getBookmarkProducts);
+};
+
+export const useAddBookmark = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation(addBookmark, {
+    onSuccess: () => {
+      notify('success', '해당 상품을 찜하였습니다.');
+      queryClient.invalidateQueries('bookmarkedProduct');
+    },
+    onError: () => {
+      notify('error', '알수 없는 이유로 해당 상품 찜에 실패하였습니다.');
+    },
+  });
+
+  return mutation;
 };
 
 export const useDeleteBookmark = () => {
   const queryClient = useQueryClient();
   const mutation = useMutation(deleteBookmark, {
     onSuccess: () => {
-      notify('success', '성공! TODO: Toast');
+      notify('success', '해당 상품을 찜목록에서 삭제하였습니다.');
       queryClient.invalidateQueries('bookmarkedProduct');
     },
     onError: () => {
-      console.log('에러');
+      notify(
+        'error',
+        '알수 없는 이유로 해당 상품을 찜목록에서 삭제에 실패하였습니다.'
+      );
+    },
+  });
+
+  return mutation;
+};
+
+export const useDeleteDetailBookmark = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation(deleteBookmark, {
+    onSuccess: () => {
+      notify('success', '해당 상품을 찜목록에서 삭제하였습니다.');
+      queryClient.invalidateQueries('detailBookmarkedProduct');
+    },
+    onError: () => {
+      notify(
+        'error',
+        '알수 없는 이유로 해당 상품을 찜목록에서 삭제에 실패하였습니다.'
+      );
     },
   });
 

--- a/client/src/lib/api/bookmark/addBookmark.ts
+++ b/client/src/lib/api/bookmark/addBookmark.ts
@@ -1,0 +1,5 @@
+import client from '../client';
+
+export const addBookmark = async (id: number) => {
+  return await client.post('/bookmark', { productId: id });
+};

--- a/client/src/lib/api/bookmark/getBookmarkProducts.ts
+++ b/client/src/lib/api/bookmark/getBookmarkProducts.ts
@@ -1,0 +1,6 @@
+import { IBookmarkProduct } from '@/types';
+import client from '../client';
+
+export const getBookmarkProducts = async () => {
+  return await client.get<number[]>(`/bookmark`);
+};

--- a/client/src/pages/Approval/Approval.tsx
+++ b/client/src/pages/Approval/Approval.tsx
@@ -29,7 +29,6 @@ const Approval = () => {
 
   const onClickNextPage = useCallback(() => {
     const { authtype } = params;
-    console.log(authtype);
     if (authtype === 'github') {
       GithubLogin();
     } else {

--- a/client/src/pages/Bookmark/Bookmark.tsx
+++ b/client/src/pages/Bookmark/Bookmark.tsx
@@ -45,10 +45,6 @@ const Bookmark = () => {
   const [user] = useRecoilState(userState);
   const [checkedList, setCheckedList] = useState<number[]>([]);
 
-  useEffect(() => {
-    console.log(checkedList);
-  }, [checkedList]);
-
   const toggleIsEdit = (val: boolean) => {
     setIsEdit(val);
   };

--- a/client/src/pages/Bookmark/Bookmark.tsx
+++ b/client/src/pages/Bookmark/Bookmark.tsx
@@ -64,16 +64,18 @@ const Bookmark = () => {
       <S.BookmarkTitle level={3}>찜 목록</S.BookmarkTitle>
       <S.ButtonContainer>
         {isEdit ? (
-          <S.EditButton
-            type="button"
-            color="primary"
-            size="Small"
-            onClick={() => {
-              toggleIsEdit(false);
-            }}
-          >
-            편집
-          </S.EditButton>
+          !!data?.length && (
+            <S.EditButton
+              type="button"
+              color="primary"
+              size="Small"
+              onClick={() => {
+                toggleIsEdit(false);
+              }}
+            >
+              편집
+            </S.EditButton>
+          )
         ) : (
           <>
             <S.EditButton

--- a/client/src/pages/Bookmark/Bookmark.tsx
+++ b/client/src/pages/Bookmark/Bookmark.tsx
@@ -1,7 +1,7 @@
 import Card from '@/components/Card';
 import CardWrapper from '@/components/CardWrapper';
 import {
-  useDeleteBookmark,
+  useDeleteDetailBookmark,
   useGetDetailBookmarkProducts,
 } from '@/hooks/queries/bookmark';
 import { Redirect } from '@/lib/Router';
@@ -41,7 +41,7 @@ const renderProducts = (
 const Bookmark = () => {
   const [isEdit, setIsEdit] = useState(true);
   const { isLoading, data } = useGetDetailBookmarkProducts();
-  const { mutate } = useDeleteBookmark();
+  const { mutate } = useDeleteDetailBookmark();
   const [user] = useRecoilState(userState);
   const [checkedList, setCheckedList] = useState<number[]>([]);
 

--- a/client/src/pages/Main/Main.tsx
+++ b/client/src/pages/Main/Main.tsx
@@ -9,6 +9,7 @@ import {
   useGetRecentProducts,
 } from '@/hooks/queries/product';
 import { IProduct } from '@/types';
+import { useGetBookmarkIds } from '@/hooks/queries/bookmark';
 
 export interface IProductQuery {
   data: IProduct[] | undefined;
@@ -19,6 +20,8 @@ const Main = () => {
   const recommandQuery = useGetRecommandProducts();
   const bestQuery = useGetBestProducts();
   const recentQuery = useGetRecentProducts();
+  const { data: bookmarkIdList } = useGetBookmarkIds();
+  console.log(bookmarkIdList);
 
   const renderProducts = (qurey: IProductQuery) => {
     const { data, isLoading } = qurey;
@@ -33,6 +36,7 @@ const Main = () => {
         src={product.productImage[0].url}
         price={product.price}
         title={product.title}
+        bookmarkList={bookmarkIdList}
       />
     ));
   };

--- a/client/src/pages/Main/Main.tsx
+++ b/client/src/pages/Main/Main.tsx
@@ -21,7 +21,6 @@ const Main = () => {
   const bestQuery = useGetBestProducts();
   const recentQuery = useGetRecentProducts();
   const { data: bookmarkIdList } = useGetBookmarkIds();
-  console.log(bookmarkIdList);
 
   const renderProducts = (qurey: IProductQuery) => {
     const { data, isLoading } = qurey;


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->

- 카드 컴포넌트 찜 기능 연동
- 메인 페이지 카드 컴포넌트 찜 정보 동기화

지금 찜 목록을 광클하면 되기는 하지만 성능상에 있어서 모든 컴포넌트를 재랜더해서 살짝 느려보이는 문제가 있는 것 같습니다.
아니면 찜을 한번 누르면 잠깐동안 못누르는 기능을 넣거나 하면 될 것 같습니다. 이에대한 의견 부탁드립니다!

## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 ex. #10 -->

#167 

## 추가 구현 필요사항

남은건 찜목록 인피니티 스크롤이 끝

## 스크린샷

- Storybook 리뷰/테스트 참고
