### PR TITLE
주문 결제 페이지 연동

### DIFF
--- a/client/src/components/Address/AddressForm/AddressForm.tsx
+++ b/client/src/components/Address/AddressForm/AddressForm.tsx
@@ -9,10 +9,12 @@ import useModal from '@/hooks/useModal';
 import * as S from './styles';
 
 interface IProps {
+  address: IAddress | null;
   addressToModify: IAddress | null;
   toggleModal: () => void;
   setAddressToModify: Dispatch<IAddress | null>;
   setOpenForm: Dispatch<boolean>;
+  selectAddress: Dispatch<IAddress>;
 }
 
 const AddressForm = ({
@@ -20,6 +22,8 @@ const AddressForm = ({
   toggleModal,
   setAddressToModify,
   setOpenForm,
+  address,
+  selectAddress,
 }: IProps) => {
   const [isPostcodeOpen, toggleIsPostcodeOpen] = useModal(false);
   const [inputs, setInputs] = useState<IAddress>({
@@ -94,6 +98,9 @@ const AddressForm = ({
     if (addressToModify) {
       updateMutation.mutate({ ...inputs });
       setOpenForm(false);
+      if (address?.id === addressToModify.id) {
+        selectAddress({ ...inputs });
+      }
     } else {
       postMutation.mutate({ ...inputs });
       toggleModal();

--- a/client/src/components/Order/OrderAddress/OrderAddress.tsx
+++ b/client/src/components/Order/OrderAddress/OrderAddress.tsx
@@ -1,12 +1,23 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, Dispatch } from 'react';
 import * as S from './styles';
 import { DELIVERY_REQUEST_MESSAGES } from '@/contstants';
 import AddressModal from '@/components/Shared/Modal/AddressModal';
 import useModal from '@/hooks/useModal';
 import { useGetDefaultAddress } from '@/hooks/queries/address';
-import { IAddress } from '@/types';
+import { IAddress, IOrder } from '@/types';
 
-const OrderAddress = () => {
+interface IProps {
+  setOrder: Dispatch<
+    Partial<IOrder> | ((prev: Partial<IOrder>) => Partial<IOrder>)
+  >;
+  updateDefaultAddress: boolean;
+  setUpdateDefaultAddress: Dispatch<boolean>;
+}
+const OrderAddress = ({
+  setOrder,
+  updateDefaultAddress,
+  setUpdateDefaultAddress,
+}: IProps) => {
   const [requestMessage, setRequestMessage] = useState('');
   const [requestMessageInput, setRequestMessageInput] = useState('');
   const [address, selectAddress] = useState<IAddress | null>(null);
@@ -17,6 +28,25 @@ const OrderAddress = () => {
       selectAddress(data);
     }
   }, [data]);
+
+  useEffect(() => {
+    const delivery_request_message =
+      requestMessage === '직접입력' ? requestMessageInput : requestMessage;
+    setOrder((prev: Partial<IOrder>) => ({
+      ...prev,
+      ...(address ? { address_id: address.id } : {}),
+      ...(delivery_request_message
+        ? { delivery_request_message }
+        : { delivery_request_message: null }),
+    }));
+  }, [
+    data,
+    setOrder,
+    address,
+    requestMessage,
+    requestMessageInput,
+    updateDefaultAddress,
+  ]);
 
   const onChangeSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setRequestMessage(e.currentTarget.value);
@@ -40,7 +70,13 @@ const OrderAddress = () => {
         </S.AddressText>
         <S.PhoneText>{address.phone}</S.PhoneText>
 
-        {!address.isDefault && <S.AddressCheckbox label="기본 배송지로 저장" />}
+        {!address.isDefault && (
+          <S.AddressCheckbox
+            label="기본 배송지로 저장"
+            checked={updateDefaultAddress}
+            onChange={(e) => setUpdateDefaultAddress(e.currentTarget.checked)}
+          />
+        )}
 
         <S.AddressSelect
           items={DELIVERY_REQUEST_MESSAGES}

--- a/client/src/components/Order/OrderAddress/OrderAddress.tsx
+++ b/client/src/components/Order/OrderAddress/OrderAddress.tsx
@@ -68,7 +68,11 @@ const OrderAddress = () => {
       {isLoading || !data ? <div>Loading...</div> : renderAddressInfo()}
 
       {isOpen && (
-        <AddressModal toggleModal={toggleModal} selectAddress={selectAddress} />
+        <AddressModal
+          toggleModal={toggleModal}
+          selectAddress={selectAddress}
+          address={address}
+        />
       )}
     </article>
   );

--- a/client/src/components/Order/OrderSummary/OrderSummary.tsx
+++ b/client/src/components/Order/OrderSummary/OrderSummary.tsx
@@ -6,16 +6,18 @@ import Title from '@/components/Shared/Title';
 
 interface IProps {
   totalPrice: number;
-  deliveryFee?: number;
-  discount?: number;
+  deliveryFee: number;
+  discount: number;
   productCount: number;
+  updateOrder: () => void;
 }
 
 const OrderSummary = ({
   totalPrice,
-  deliveryFee = 0,
-  discount = 0,
+  deliveryFee,
+  discount,
   productCount,
+  updateOrder,
 }: IProps) => {
   const sum = totalPrice + deliveryFee - discount;
   return (
@@ -34,7 +36,7 @@ const OrderSummary = ({
         </S.OrderSummaryRow>
         <S.OrderSummaryRow>
           <dt>쿠폰 사용</dt>
-          <dd>
+          <dd className={discount > 0 ? 'red' : undefined}>
             {discount > 0 ? '-' : ''} {wonFormat(discount)}
           </dd>
         </S.OrderSummaryRow>
@@ -44,7 +46,13 @@ const OrderSummary = ({
           <dd>{wonFormat(sum)}</dd>
         </S.OrderSummaryRow>
       </S.OrderSummary>
-      <Button type="button" color="primary" onClick={() => {}}>
+      <Button
+        type="button"
+        color="primary"
+        onClick={() => {
+          updateOrder();
+        }}
+      >
         {productCount}개 상품 구매하기
       </Button>
     </S.OrderSummaryWrapper>

--- a/client/src/components/Order/OrderSummary/styles.ts
+++ b/client/src/components/Order/OrderSummary/styles.ts
@@ -38,6 +38,9 @@ export const OrderSummaryRow = styled.div`
   dd {
     ${({ theme }) => theme.fontSize.m}
     ${({ theme }) => theme.fontWeight.l}
+    &.red {
+      color: ${({ theme }) => theme.color.error};
+    }
   }
 
   &:last-child {

--- a/client/src/components/Shared/Modal/AddressModal/AddressModal.tsx
+++ b/client/src/components/Shared/Modal/AddressModal/AddressModal.tsx
@@ -10,9 +10,10 @@ import * as S from './styles';
 interface IProps {
   toggleModal: () => void;
   selectAddress: Dispatch<IAddress>;
+  address: IAddress | null;
 }
 
-const AddressModal = ({ toggleModal, selectAddress }: IProps) => {
+const AddressModal = ({ toggleModal, selectAddress, address }: IProps) => {
   const [openForm, setOpenForm] = useState(false);
   const [addressToModify, setAddressToModify] = useState<IAddress | null>(null);
 
@@ -42,6 +43,8 @@ const AddressModal = ({ toggleModal, selectAddress }: IProps) => {
           addressToModify={addressToModify}
           setAddressToModify={setAddressToModify}
           setOpenForm={setOpenForm}
+          address={address}
+          selectAddress={selectAddress}
         />
       ) : (
         <Address

--- a/client/src/components/ShoppingCart/ShoppingCartSummary/ShoppingCartSummary.stories.tsx
+++ b/client/src/components/ShoppingCart/ShoppingCartSummary/ShoppingCartSummary.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import shoppingCart from '@/dummies/shoppingCart';
-import { shoppingCartItem } from '@/types';
+import { ICart } from '@/types';
 import ShoppingCartSummary from '.';
 
 export default {
@@ -9,15 +9,14 @@ export default {
   component: ShoppingCartSummary,
 } as ComponentMeta<typeof ShoppingCartSummary>;
 
-const initialItems = shoppingCart.map((item) => ({
-  ...item,
-  isChekced: true,
-}));
-
 const Template: ComponentStory<typeof ShoppingCartSummary> = () => {
-  const [shoppingCartItems] = useState<shoppingCartItem[]>(initialItems);
+  const [shoppingCartItems] = useState<ICart[]>(shoppingCart);
+  const [unCheckedList, setUnCheckedList] = useState<number[]>([]);
+  const checkedItems = shoppingCartItems.filter(
+    (item) =>
+      !unCheckedList.find((uncheckedId) => item.productId === uncheckedId)
+  );
 
-  const checkedItems = shoppingCartItems.filter((item) => item.isChekced);
   const productCount = checkedItems.length;
   const totalPrice = checkedItems.reduce(
     (sum, item) => sum + item.price * item.count,
@@ -29,6 +28,7 @@ const Template: ComponentStory<typeof ShoppingCartSummary> = () => {
       productCount={productCount}
       totalPrice={totalPrice}
       disabled={false}
+      checkedItems={checkedItems}
     />
   );
 };

--- a/client/src/components/ShoppingCart/ShoppingCartSummary/ShoppingCartSummary.tsx
+++ b/client/src/components/ShoppingCart/ShoppingCartSummary/ShoppingCartSummary.tsx
@@ -2,7 +2,8 @@ import React, { useCallback } from 'react';
 import * as S from './styles';
 import { wonFormat } from '@/utils/helper';
 import Button from '@/components/Shared/Button';
-import { useHistory } from '@/lib/Router';
+import { usePostOrder } from '@/hooks/queries/order';
+import { ICart } from '@/types';
 
 interface ISShoppingCartSummaryProps {
   totalPrice: number;
@@ -10,21 +11,28 @@ interface ISShoppingCartSummaryProps {
   discount?: number;
   productCount: number;
   disabled?: boolean;
+  checkedItems: ICart[];
 }
 
 const ShoppingCartSummary = ({
   totalPrice,
-  deliveryFee = 0,
+  deliveryFee = 2500,
   discount = 0,
   productCount,
   disabled,
+  checkedItems,
 }: ISShoppingCartSummaryProps) => {
   const sum = totalPrice + deliveryFee - discount;
-  const { historyPush } = useHistory();
-
+  const { mutate } = usePostOrder();
   const buyButtonOnClick = useCallback(() => {
-    historyPush('/order');
-  }, [historyPush]);
+    mutate({
+      products: checkedItems.map((item) => ({
+        count: item.count,
+        id: item.productId,
+      })),
+      status: 'created',
+    });
+  }, [mutate, checkedItems]);
 
   return (
     <S.ShoppingCartSummaryWrapper>
@@ -39,7 +47,10 @@ const ShoppingCartSummary = ({
         </S.ShoppingCartSummaryRow>
         <S.ShoppingCartSummaryRow>
           <dt>총 할인금액</dt>
-          <dd>+ {wonFormat(discount)}</dd>
+          <dd>
+            {!!discount && '+ '}
+            {wonFormat(discount)}
+          </dd>
         </S.ShoppingCartSummaryRow>
         <S.ShoppingCartSummaryRow>
           <dt>결제 금액</dt>

--- a/client/src/dummies/shoppingCart.ts
+++ b/client/src/dummies/shoppingCart.ts
@@ -1,50 +1,62 @@
 export default [
   {
-    id: 1,
+    productId: 1,
     title: '물 반 휴지 반',
     price: 2000,
     count: 3,
     deliveryFee: 0,
-    discount: 0,
+    createdAt: '2021-09-09',
+    image:
+      'https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885__480.jpg',
   },
   {
-    id: 2,
+    productId: 2,
     title: '물 반 휴지 반',
     price: 2000,
     count: 1,
     deliveryFee: 0,
-    discount: 0,
+    createdAt: '2021-09-09',
+    image:
+      'https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885__480.jpg',
   },
   {
-    id: 3,
+    productId: 3,
     title: '물 반 휴지 반',
     price: 2000,
     count: 2,
     deliveryFee: 0,
-    discount: 0,
+    createdAt: '2021-09-09',
+    image:
+      'https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885__480.jpg',
   },
   {
-    id: 4,
+    productId: 4,
     title: '물 반 휴지 반',
     price: 2000,
     count: 4,
     deliveryFee: 0,
-    discount: 0,
+    createdAt: '2021-09-09',
+    image:
+      'https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885__480.jpg',
   },
   {
-    id: 5,
+    productId: 5,
     title: '물 반 휴지 반',
     price: 2000,
     count: 5,
     deliveryFee: 0,
-    discount: 0,
+    createdAt: '2021-09-09',
+    image:
+      'https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885__480.jpg',
   },
   {
-    id: 6,
+    productId: 6,
     title: '물 반 휴지 반',
     price: 2000,
     count: 6,
     deliveryFee: 0,
-    discount: 0,
+    createdAt: '2021-09-09',
+    image:
+      'https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885__480.jpg',
   },
 ];

--- a/client/src/hooks/queries/order/index.tsx
+++ b/client/src/hooks/queries/order/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation } from 'react-query';
-import { getOrder, postOrder, getOrders } from '@/lib/api/order';
+import { getOrder, postOrder, getOrders, updateOrder } from '@/lib/api/order';
 import { IOrder } from '@/types';
 import { useHistory } from '@/lib/Router';
 
@@ -19,5 +19,14 @@ export const usePostOrder = () => {
 export const useGetOrders = (year: number | null) => {
   return useQuery<IOrder[], Error>(['orders', year], () => getOrders(year), {
     keepPreviousData: true,
+  });
+};
+
+export const useUpdateOrder = () => {
+  const { historyPush } = useHistory();
+  return useMutation(updateOrder, {
+    onSuccess(data) {
+      historyPush(`/order/${data.id}/paid`);
+    },
   });
 };

--- a/client/src/lib/api/client.ts
+++ b/client/src/lib/api/client.ts
@@ -47,4 +47,13 @@ export default {
       return throwError(e);
     }
   },
+
+  async patch<T>(url: string, body: T) {
+    try {
+      const res = await client.patch(url, body);
+      return res.data.result;
+    } catch (e) {
+      return throwError(e);
+    }
+  },
 };

--- a/client/src/lib/api/order/index.ts
+++ b/client/src/lib/api/order/index.ts
@@ -1,5 +1,5 @@
 import client from '../client';
-import { IOrder, IOrderPost } from '@/types';
+import { IOrder, IOrderPost, IOrderUpdate } from '@/types';
 
 export const postOrder = async (order: IOrderPost) => {
   return await client.post<IOrderPost>('/order', order);
@@ -11,4 +11,8 @@ export const getOrder = async (id: number) => {
 
 export const getOrders = async (year: number | null) => {
   return await client.get<IOrder[]>(`/order${year ? `?year=${year}` : ''}`);
+};
+
+export const updateOrder = async (updateOrder: IOrderUpdate) => {
+  return await client.patch<IOrderUpdate>('/order', updateOrder);
 };

--- a/client/src/pages/ShoppingCart/ShoppingCart.tsx
+++ b/client/src/pages/ShoppingCart/ShoppingCart.tsx
@@ -49,13 +49,16 @@ const ShoppingCart = () => {
       />
       <S.ShoppingCartAside>
         <ShoppingCartSummary
+          checkedItems={checkedItems}
           productCount={productCount}
           totalPrice={totalPrice}
           disabled={disabled}
         />
       </S.ShoppingCartAside>
+
       <S.ShoppingCartFooter>
         <ShoppingCartSummary
+          checkedItems={checkedItems}
           productCount={productCount}
           totalPrice={totalPrice}
           disabled={disabled}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -164,10 +164,15 @@ export interface IOrder {
   id: number;
   products: IOrderProduct[];
   status: string;
-  address_id: number;
+  address_id?: number | null;
   user_id: number;
-  delivery_request_message: string;
+  delivery_request_message?: string | null;
   deliveredAt?: string;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface IOrderUpdate {
+  order: Partial<IOrder>;
+  updateDefaultAddress?: boolean;
 }

--- a/server/src/api/routes/order.router.ts
+++ b/server/src/api/routes/order.router.ts
@@ -4,6 +4,7 @@ import OrderController from '@/controllers/order.controller';
 
 const router = Router();
 
+router.patch('/', wrapAsync(OrderController.updateOrder));
 router.post('/', wrapAsync(OrderController.createOrder));
 router.get('/', wrapAsync(OrderController.getOrders));
 router.get('/:id', wrapAsync(OrderController.getOrder));

--- a/server/src/repositories/address.repository.ts
+++ b/server/src/repositories/address.repository.ts
@@ -32,13 +32,13 @@ class AddressRepository extends Repository<Address> {
     return this.save(address);
   }
 
-  async updateAddress(addressData: IAddress) {
+  async updateAddress(addressData: Partial<IAddress>) {
     return this.update(addressData.id, addressData);
   }
 
   async removeDefaultAddress(user_id: number) {
     return this.update(
-      { user_id },
+      { user_id, is_default: true },
       {
         is_default: false,
       }

--- a/server/src/repositories/order.repository.ts
+++ b/server/src/repositories/order.repository.ts
@@ -11,6 +11,7 @@ import {
 } from 'typeorm';
 
 interface IOrder {
+  id?: number;
   products: {
     count: number;
     id: number;
@@ -68,7 +69,6 @@ class OrderRepository extends Repository<Order> {
       : addMonth(new Date(), -DEFAULT_MONTH_AGO);
     const endDate = year ? new Date(`${year}-12-31`) : new Date();
 
-    console.log(startDate, endDate);
     return this.find({
       where: {
         user_id,
@@ -77,6 +77,10 @@ class OrderRepository extends Repository<Order> {
       },
       relations: ['products', 'products.productImage'],
     });
+  }
+
+  async updateOrder(order: Partial<IOrder>) {
+    return this.update(order.id, order);
   }
 }
 

--- a/server/src/services/order.service.ts
+++ b/server/src/services/order.service.ts
@@ -1,5 +1,6 @@
 import OrderRepository from '@/repositories/order.repository';
 import OrderProductRepository from '@/repositories/orderProduct.repository';
+import AddressRepository from '@/repositories/address.repository';
 
 class OrderService {
   async createOrder({
@@ -71,6 +72,20 @@ class OrderService {
         price: product.price,
       })),
     }));
+  }
+
+  async updateOrder({ user_id, order, updateDefaultAddress }) {
+    if (updateDefaultAddress) {
+      const addressRepo = AddressRepository();
+      await addressRepo.removeDefaultAddress(user_id);
+      await addressRepo.updateAddress({
+        is_default: updateDefaultAddress,
+        id: order.address_id,
+      });
+    }
+
+    const orderRepo = OrderRepository();
+    return await orderRepo.updateOrder({ user_id, ...order });
   }
 }
 


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->
- 장바구니에서 결제 페이지로 이동
- 결제 api 연동 (Order update)
- 선택된 주소 수정시 업데이트 안되는 버그 수정

## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 ex. #10 -->

closes #170 

## 추가 구현 필요사항
- 결제에 쿠폰 적용
- 결제 수단(?) - 이건 아마 마크업만..
- 결제 완료 페이지 (지금은 404)
## 스크린샷

- Storybook 리뷰/테스트 참고
