### PR TITLE
인피니티 스크롤 구현 및 유저 버그 수정

### DIFF
--- a/client/src/components/Card/Card.tsx
+++ b/client/src/components/Card/Card.tsx
@@ -7,6 +7,9 @@ import {
 import { Link } from '@/lib/Router';
 import { wonFormat } from '@/utils/helper';
 import { useAddBookmark, useDeleteBookmark } from '@/hooks/queries/bookmark';
+import { useRecoilState } from 'recoil';
+import { userState } from '@/recoil/user';
+import { notify } from '../Shared/Toastify';
 
 interface CardProps {
   bgColor: 'error' | 'primary'; // category 식으로 리스트화 (enum 등..) 필요
@@ -43,6 +46,8 @@ const Card = ({
     e.preventDefault();
   };
 
+  const [user] = useRecoilState(userState);
+
   const isChecked = !!checkedList?.find((checkedId) => checkedId === linkId);
 
   const onChangeCheckbox = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -62,12 +67,13 @@ const Card = ({
   }, []);
 
   const heartBtnOnClick = useCallback(() => {
-    if (isHeartChecked) {
+    if (!user) notify('error', '로그인이 필요합니다!');
+    else if (isHeartChecked) {
       deleteMutate([linkId]);
     } else {
       addMutate(linkId);
     }
-  }, [addMutate, deleteMutate, isHeartChecked, linkId]);
+  }, [addMutate, deleteMutate, isHeartChecked, linkId, user]);
 
   return (
     <Link to={`/detail/${linkId}`}>

--- a/client/src/components/Skeleton/CardSkeleton/styles.ts
+++ b/client/src/components/Skeleton/CardSkeleton/styles.ts
@@ -22,7 +22,7 @@ export const SkeletonCard = styled.li`
 `;
 
 export const SkeletonImg = styled.div`
-  width: 100%;
+  width: 24rem;
   height: 24rem;
   border-radius: 10px;
   background: #f2f2f2;

--- a/client/src/hooks/queries/bookmark/index.tsx
+++ b/client/src/hooks/queries/bookmark/index.tsx
@@ -4,10 +4,16 @@ import { deleteBookmark } from '@/lib/api/bookmark/deleteBookmark';
 import { getBookmarkProducts } from '@/lib/api/bookmark/getBookmarkProducts';
 import { getDetailBookmarkProducts } from '@/lib/api/bookmark/getDetailBookmarkProducts';
 import { IBookmarkProduct } from '@/types';
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import {
+  InfiniteData,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from 'react-query';
 
 export const useGetDetailBookmarkProducts = () => {
-  return useQuery<IBookmarkProduct[], Error>(
+  return useInfiniteQuery<IBookmarkProduct[], Error>(
     'detailBookmarkedProduct',
     getDetailBookmarkProducts
   );
@@ -55,9 +61,27 @@ export const useDeleteBookmark = () => {
 export const useDeleteDetailBookmark = () => {
   const queryClient = useQueryClient();
   const mutation = useMutation(deleteBookmark, {
+    onMutate: async (deleteBookmark) => {
+      await queryClient.cancelQueries('detailBookmarkedProduct');
+      const previousBookmarks = queryClient.getQueryData(
+        'detailBookmarkedProduct'
+      );
+
+      queryClient.setQueryData<InfiniteData<IBookmarkProduct[]> | undefined>(
+        'detailBookmarkedProduct',
+        (old) => {
+          if (!old) return;
+          const { pages } = old;
+          const data = pages.map((page) =>
+            page.filter((pg) => !deleteBookmark.includes(pg.productId))
+          );
+          return { ...old, pages: data };
+        }
+      );
+      return { previousBookmarks };
+    },
     onSuccess: () => {
       notify('success', '해당 상품을 찜목록에서 삭제하였습니다.');
-      queryClient.invalidateQueries('detailBookmarkedProduct');
     },
     onError: () => {
       notify(

--- a/client/src/hooks/queries/bookmark/index.tsx
+++ b/client/src/hooks/queries/bookmark/index.tsx
@@ -13,8 +13,10 @@ export const useGetDetailBookmarkProducts = () => {
   );
 };
 
-export const useGetBookmarkIds = () => {
-  return useQuery<number[], Error>('bookmarkedProduct', getBookmarkProducts);
+export const useGetBookmarkIds = (enabled: boolean) => {
+  return useQuery<number[], Error>('bookmarkedProduct', getBookmarkProducts, {
+    enabled,
+  });
 };
 
 export const useAddBookmark = () => {

--- a/client/src/hooks/useInfiniteScroll.tsx
+++ b/client/src/hooks/useInfiniteScroll.tsx
@@ -19,7 +19,7 @@ const useInfiniteScroll = <T extends unknown>({
 }: IInfinityScroll<T>) => {
   const { ref, inView } = useInView(inViewOption);
 
-  const { data, isLoading, isFetching,fetchNextPage, error, status } =
+  const { data, isLoading, isFetching, fetchNextPage, error, status, remove } =
     useInfiniteQuery<T>(
       key,
       () =>
@@ -40,6 +40,7 @@ const useInfiniteScroll = <T extends unknown>({
     error,
     status,
     ref,
+    remove,
   };
 };
 

--- a/client/src/layouts/App/App.tsx
+++ b/client/src/layouts/App/App.tsx
@@ -24,23 +24,34 @@ import { ErrorBoundary } from 'react-error-boundary';
 import Error from '@/components/Shared/Error';
 import { useRecoilState } from 'recoil';
 import { userState } from '@/recoil/user';
-import { getCurrentUser } from '@/lib/api/user/getCurrentUser';
 import Bookmark from '@/pages/Bookmark';
+import { getCurrentUser } from '@/lib/api/user/getCurrentUser';
 
 const App = () => {
   const [theme, setTheme] = useState('light-mode');
   const themeMode = theme === 'light-mode' ? lightMode : darkMode;
-  const [user, setUser] = useRecoilState(userState);
 
   const toggleMode = () =>
     setTheme(theme === 'light-mode' ? 'dark-mode' : 'light-mode');
 
+  const [user, setUser] = useRecoilState(userState);
+  const [loading, setLoading] = useState(true);
   const getInitialUser = useCallback(async () => {
     if (!user) {
-      const initialUser = await getCurrentUser();
-      setUser(initialUser);
+      try {
+        const data = await getCurrentUser();
+        setUser(data);
+      } catch (e) {
+        setLoading(false);
+      }
     }
   }, [user, setUser]);
+
+  useEffect(() => {
+    if (user) {
+      setLoading(false);
+    }
+  }, [user]);
 
   useEffect(() => {
     getInitialUser();
@@ -57,29 +68,33 @@ const App = () => {
                 <Error resetErrorBoundary={resetErrorBoundary} />
               )}
             >
-              <S.RootWrapper>
-                <S.ToggleButton onClick={toggleMode}>
-                  라이트/다크모드
-                </S.ToggleButton>
-                <Header />
-                <Switch>
-                  <Route path="/" component={Main} />
-                  <Route path="/select_auth" component={SelectAuth} />
-                  <Route path="/approval/:authtype" component={Approval} />
-                  <Route path="/bookmark" component={Bookmark} />
-                  <Route path="/category/:categoryId" component={Category} />
-                  <Route path="/search/:search" component={Search} />
-                  <Route path="/signup" component={SignUp} />
-                  <Route path="/login" component={Login} />
-                  <Route path="/detail/:id" component={Detail} />
-                  <Route path="/notice" component={Notice} />
-                  <Route path="/cart" component={ShoppingCart} />
-                  <Route path="/mypage" component={MyPage} />
-                  <Route path="/order/:id" component={Order} />
-                  <Route path="/*" component={NotFound} />
-                </Switch>
-                <Footer />
-              </S.RootWrapper>
+              {loading ? (
+                <Loading />
+              ) : (
+                <S.RootWrapper>
+                  <S.ToggleButton onClick={toggleMode}>
+                    라이트/다크모드
+                  </S.ToggleButton>
+                  <Header />
+                  <Switch>
+                    <Route path="/" component={Main} />
+                    <Route path="/select_auth" component={SelectAuth} />
+                    <Route path="/approval/:authtype" component={Approval} />
+                    <Route path="/bookmark" component={Bookmark} />
+                    <Route path="/category/:categoryId" component={Category} />
+                    <Route path="/search/:search" component={Search} />
+                    <Route path="/signup" component={SignUp} />
+                    <Route path="/login" component={Login} />
+                    <Route path="/detail/:id" component={Detail} />
+                    <Route path="/notice" component={Notice} />
+                    <Route path="/cart" component={ShoppingCart} />
+                    <Route path="/mypage" component={MyPage} />
+                    <Route path="/order/:id" component={Order} />
+                    <Route path="/*" component={NotFound} />
+                  </Switch>
+                  <Footer />
+                </S.RootWrapper>
+              )}
             </ErrorBoundary>
           )}
         </QueryErrorResetBoundary>

--- a/client/src/lib/api/bookmark/getDetailBookmarkProducts.ts
+++ b/client/src/lib/api/bookmark/getDetailBookmarkProducts.ts
@@ -1,6 +1,12 @@
 import { IBookmarkProduct } from '@/types';
 import client from '../client';
 
-export const getDetailBookmarkProducts = async () => {
-  return await client.get<IBookmarkProduct[]>(`/bookmark/detail`);
+export const getDetailBookmarkProducts = async ({
+  pageParam = {
+    start: 0,
+  },
+}) => {
+  return await client.get<IBookmarkProduct[]>(
+    `/bookmark/detail?start=${pageParam.start}`
+  );
 };

--- a/client/src/pages/Bookmark/Bookmark.tsx
+++ b/client/src/pages/Bookmark/Bookmark.tsx
@@ -1,5 +1,6 @@
 import Card from '@/components/Card';
 import CardWrapper from '@/components/CardWrapper';
+import { notify } from '@/components/Shared/Toastify';
 import Thung from '@/components/Thung';
 import {
   useDeleteDetailBookmark,
@@ -8,7 +9,7 @@ import {
 import { Redirect } from '@/lib/Router';
 import { userState } from '@/recoil/user';
 import { IBookmarkProduct } from '@/types';
-import React, { Dispatch, useState } from 'react';
+import React, { Dispatch, useCallback, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import * as S from './style';
 
@@ -50,9 +51,14 @@ const Bookmark = () => {
     setIsEdit(val);
   };
 
-  const removeBookmarkItems = () => {
-    mutate(checkedList);
-  };
+  const removeBookmarkItems = useCallback(() => {
+    if (checkedList.length === 0) {
+      notify('error', '삭제할 상품을 한개 이상 선택해주세요!');
+    } else {
+      mutate(checkedList);
+      setCheckedList([]);
+    }
+  }, [checkedList, mutate]);
 
   if (!user) return <Redirect to="/" />;
 

--- a/client/src/pages/Main/Main.tsx
+++ b/client/src/pages/Main/Main.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import * as S from './styles';
 import Card from '@/components/Card';
 import Banner from '@/components/Banner';
@@ -10,6 +10,8 @@ import {
 import { IProduct } from '@/types';
 import { useGetBookmarkIds } from '@/hooks/queries/bookmark';
 import LoadingCards from '@/components/Skeleton/LoadingCards';
+import { useRecoilState } from 'recoil';
+import { userState } from '@/recoil/user';
 
 export interface IProductQuery {
   data: IProduct[] | undefined;
@@ -20,7 +22,14 @@ const Main = () => {
   const recommandQuery = useGetRecommandProducts();
   const bestQuery = useGetBestProducts();
   const recentQuery = useGetRecentProducts();
-  const { data: bookmarkIdList } = useGetBookmarkIds();
+  const [user] = useRecoilState(userState);
+  const { data: bookmarkIdList, remove } = useGetBookmarkIds(!!user);
+
+  useEffect(() => {
+    if (!user) {
+      remove();
+    }
+  }, [user, remove]);
 
   const renderProducts = (qurey: IProductQuery) => {
     const { data, isLoading } = qurey;

--- a/client/src/pages/Main/Main.tsx
+++ b/client/src/pages/Main/Main.tsx
@@ -48,6 +48,7 @@ const Main = () => {
       />
     ));
   };
+
   return (
     <>
       <Banner />
@@ -55,7 +56,7 @@ const Main = () => {
         <h1 className="product-title">새로 나왔어요!</h1>
         <LoadingCards
           col={4}
-          skeletonNum={4}
+          skeletonNum={8}
           showSkeleton={recentQuery.isLoading || recentQuery.isFetching}
           component={renderProducts(recentQuery)}
         />
@@ -63,7 +64,7 @@ const Main = () => {
         <h1 className="product-title">이거는 어때요?</h1>
         <LoadingCards
           col={4}
-          skeletonNum={4}
+          skeletonNum={8}
           showSkeleton={recommandQuery.isLoading || recommandQuery.isFetching}
           component={renderProducts(recommandQuery)}
         />

--- a/server/src/controllers/bookmark.controller.ts
+++ b/server/src/controllers/bookmark.controller.ts
@@ -21,7 +21,11 @@ class BookmarkController {
 
   async getBookmarksDetail(req: Request, res: Response) {
     const userId = req.user.id;
-    const bookmarks = await BookmarkService.getBookmarksDetail(userId);
+    const { start } = req.query;
+    const bookmarks = await BookmarkService.getBookmarksDetail({
+      userId,
+      start: +start,
+    });
 
     ApiResponse(res, HttpStatusCode.OK, '찜 목록 상세 조회 성공', bookmarks);
   }

--- a/server/src/repositories/bookmark.repository.ts
+++ b/server/src/repositories/bookmark.repository.ts
@@ -22,10 +22,13 @@ class BookmarkRepository extends Repository<Bookmark> {
     return this.save(Bookmark);
   }
 
-  getBookmarksDetail(userId: number): Promise<Bookmark[]> {
+  getBookmarksDetail(userId: number, start: number): Promise<Bookmark[]> {
     // TODO: productimage 하나만 가져오기
+    console.log(start);
     const Bookmarks = this.find({
+      skip: start,
       where: { user_id: userId },
+      take: 8,
       relations: ['product', 'product.productImage'],
     });
     return Bookmarks;

--- a/server/src/services/bookmark.service.ts
+++ b/server/src/services/bookmark.service.ts
@@ -17,9 +17,9 @@ class BookmarkService {
     });
   }
 
-  async getBookmarksDetail(userId) {
+  async getBookmarksDetail({ userId, start }) {
     const bookmarkRepo = BookmarkRepository();
-    const bookmarks = await bookmarkRepo.getBookmarksDetail(userId);
+    const bookmarks = await bookmarkRepo.getBookmarksDetail(userId, start);
 
     return bookmarks.map((bookmark) => {
       const img = bookmark.product.productImage.find(


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->

- 유저 auth가 있어야만 접속할 수 있는 페이지에서 새로고침을 누를시에 메인으로 리다이렉트 되는 버그가 있었습니다
이 버그를 유저를 App.tsx에서 유저 상태를 받아온 후에 다른 페이지들로 돔에 접근할 수 있도록 변경(버그수정) 하였습니다.
- 인피니티 스크롤을 구현했어요. 이부분도 덕분에 잘 할 수 있었습니다. 버그가 추가적으로 나올지는 잘모르겠네요 제가 해본경우에는 버그는 찾지 못했습니다.

찜페이지 진짜 끝? 강열님이 말하신 전체삭제정도?가 있지않을까 싶네요 만약 시간이 남아서 더한다면?

## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 ex. #10 -->

closes #167 

## 추가 구현 필요사항

없음

## 스크린샷

- Storybook 리뷰/테스트 참고
