### PR TITLE
ContentParser 파싱 로직 변경

### DIFF
--- a/client/src/components/ProductDetails/ProductDescription/ProductDescription.tsx
+++ b/client/src/components/ProductDetails/ProductDescription/ProductDescription.tsx
@@ -22,6 +22,7 @@ const ProductDescription = () => {
   const { content } = data.details;
   const { details, essentials } = content;
   const [images, tables] = contentParser({ details, essentials });
+  const imageFiles = images.filter((image) => image !== 'NO-IMAGE');
 
   return (
     <S.PanelWrapper>
@@ -38,9 +39,21 @@ const ProductDescription = () => {
         ))}
       </S.ProductTable>
 
-      {images.map((image) => {
+      {imageFiles.map((image) => {
         return <img key={nanoid()} src={image} alt="상품 상세정보 이미지" />;
       })}
+
+      {!imageFiles.length && (
+        <S.PreparingWrapper>
+          <img
+            src="https://store-10.s3.ap-northeast-2.amazonaws.com/test/baemin_ddam.gif"
+            alt="상품 준비중 이미지"
+          />
+          <S.PreparingText>
+            해당 상품 이미지를 아직 준비중에 있어요...
+          </S.PreparingText>
+        </S.PreparingWrapper>
+      )}
     </S.PanelWrapper>
   );
 };

--- a/client/src/components/ProductDetails/styles.ts
+++ b/client/src/components/ProductDetails/styles.ts
@@ -328,3 +328,22 @@ export const TopArea = styled.div`
   justify-content: space-between;
   align-items: center;
 `;
+
+export const PreparingWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 5rem;
+
+  img {
+    max-width: 50%;
+    max-height: 50%;
+  }
+`;
+
+export const PreparingText = styled.p`
+  font-family: 'BMDOHYEON';
+  ${({ theme }) => theme.fontSize.l};
+  ${({ theme }) => theme.fontWeight.l};
+`;

--- a/client/src/hooks/queries/product/index.tsx
+++ b/client/src/hooks/queries/product/index.tsx
@@ -50,11 +50,19 @@ export const useGetProductReviewsById = (id: string, offset: number) => {
   );
 };
 
+export const useGetProductQuestionById = (id: string, offset: number) => {
+  return useQuery<IProductQuestion[], Error>(
+    ['productQuestion', id, offset],
+    () => getProductQuestionById(id, offset),
+    { keepPreviousData: true }
+  );
+};
+
 export const useGetProductReviewsByUser = (offset: number) => {
   return useQuery<IMyReview, Error>(
     ['productReviewUser', offset],
     () => getProductReviewsByUser(offset),
-    { keepPreviousData: true }
+    { keepPreviousData: true, refetchOnWindowFocus: false }
   );
 };
 
@@ -62,27 +70,23 @@ export const useGetProductQuestionsByUser = (offset: number) => {
   return useQuery<IMyQuestion, Error>(
     ['productQuestionUser', offset],
     () => getProductQuestionByUser(offset),
-    { keepPreviousData: true }
+    { keepPreviousData: true, refetchOnWindowFocus: false }
   );
 };
 
 export const useGetSelectedReviewById = (id: number) => {
-  return useQuery<IProductReview, Error>(['selectedReview', id], () =>
-    getProductSelectedReview(id)
+  return useQuery<IProductReview, Error>(
+    ['selectedReview', id],
+    () => getProductSelectedReview(id),
+    { refetchOnWindowFocus: false }
   );
 };
 
 export const useGetSelectedQuestionById = (id: number) => {
-  return useQuery<IProductQuestion, Error>(['selectedQuestion', id], () =>
-    getProductSelectedQuestion(id)
-  );
-};
-
-export const useGetProductQuestionById = (id: string, offset: number) => {
-  return useQuery<IProductQuestion[], Error>(
-    ['productQuestion', id, offset],
-    () => getProductQuestionById(id, offset),
-    { keepPreviousData: true }
+  return useQuery<IProductQuestion, Error>(
+    ['selectedQuestion', id],
+    () => getProductSelectedQuestion(id),
+    { refetchOnWindowFocus: false }
   );
 };
 
@@ -100,15 +104,21 @@ export const useGetProductQuestionCount = (id: string) => {
 };
 
 export const useGetRecommandProducts = () => {
-  return useQuery<IProduct[], Error>('recommandProduct', getRecommandProducts);
+  return useQuery<IProduct[], Error>('recommandProduct', getRecommandProducts, {
+    refetchOnWindowFocus: false,
+  });
 };
 
 export const useGetBestProducts = () => {
-  return useQuery<IProduct[], Error>('bestProducts', getBestProducts);
+  return useQuery<IProduct[], Error>('bestProducts', getBestProducts, {
+    refetchOnWindowFocus: false,
+  });
 };
 
 export const useGetRecentProducts = () => {
-  return useQuery<IProduct[], Error>('recentProduct', getRecentProducts);
+  return useQuery<IProduct[], Error>('recentProduct', getRecentProducts, {
+    refetchOnWindowFocus: false,
+  });
 };
 
 export const useGetCateogries = () => {

--- a/client/src/utils/contentParser.ts
+++ b/client/src/utils/contentParser.ts
@@ -12,10 +12,18 @@ const contentParser = ({ details, essentials }: ParserProps) => {
   const jsoned_details = JSON.parse(details);
   const jsoned_essentials = JSON.parse(essentials);
 
+  console.log(jsoned_details);
+
   const images: string[] = jsoned_details.map(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (detail: Record<string, Array<any>>) =>
-      'https:' + detail.vendorItemContentDescriptions[0].content
+    (detail: any) => {
+      const type = detail.vendorItemContentDescriptions[0].detailType;
+      if (type === 'IMAGE') {
+        return 'https:' + detail.vendorItemContentDescriptions[0].content;
+      } else if (type === 'TEXT') {
+        return 'NO-IMAGE';
+      }
+    }
   );
 
   const tables: tableType[] = jsoned_essentials.slice(0, 4);


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->

- 기존 파서는 크롤링 한 데이터의 모든 content를 가져오도록 작동했으나, 일부 데이터의 경우 content에 이미지 경로가 없는 사실을 발견
- 이때 엑박 이미지가 뜨는 것을 방지하기 위해 파싱로직을 변경하여 이미지 content만 들고 올 수 있도록 수정
- 만약 가져온 이미지가 없을 경우엔 임시로 준비중이라는 것을 알리는 뷰를 렌더

## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 ex. #10 -->

closes #214 

## 추가 구현 필요사항

- 없음

## 스크린샷

- Storybook 리뷰/테스트 참고
