### PR TITLE
배송조회 버그 처리

### DIFF
--- a/client/src/components/MyPage/OrderHistory/OrderHistory.tsx
+++ b/client/src/components/MyPage/OrderHistory/OrderHistory.tsx
@@ -12,6 +12,7 @@ import Thung from '@/components/Thung';
 import { PAGE_LIMIT } from '@/utils/constant/offsetLimit';
 import useModal from '@/hooks/useModal';
 import { RequestModal, ReviewModal } from '@/components/Shared/Modal';
+import DeliveryModal from '@/components/Shared/Modal/DeliveryModal';
 
 const OrderHistory = ({}) => {
   const topRef = useRef<HTMLDivElement>(null);
@@ -21,8 +22,10 @@ const OrderHistory = ({}) => {
   const [offset, handleOnClickPage] = usePagination(PAGE_LIMIT, topRef);
   const [isOpenReviewModal, toggleReviewModal] = useModal(false);
   const [isOpenQuestionModal, toggleQuestionModal] = useModal(false);
+  const [isOpenDeliveryModal, toggleDeliveryModal] = useModal(false);
   const [seletedReview, setSelectedReview] = useState(0);
   const [selectedQuestion, setSelectedQuestion] = useState(0);
+  const [selectedOrderId, setSelectedOrderId] = useState(0);
   const { data } = useGetOrders(selectedPeriod);
 
   useEffect(() => {
@@ -33,8 +36,11 @@ const OrderHistory = ({}) => {
     } else {
       setOrders(data || []);
     }
-    handleOnClickPage(0, true);
   }, [data, selectedStatus, handleOnClickPage]);
+
+  useEffect(() => {
+    handleOnClickPage(0, true);
+  }, [selectedStatus, handleOnClickPage]);
 
   const handleOnClickItemReview = (target: number) => {
     setSelectedReview(target);
@@ -46,18 +52,23 @@ const OrderHistory = ({}) => {
     toggleQuestionModal();
   };
 
+  const handleOnClieItemDelivery = (target: number) => () => {
+    setSelectedOrderId(target);
+    toggleDeliveryModal();
+  };
+
   const renderOrderItemList = () => {
     const ordersOnPage = orders.slice(offset, offset + PAGE_LIMIT);
     return ordersOnPage.map((order) => (
       <S.OrderHistoryBody key={order.id}>
         <OrderItemList
-          orderId={order.id}
           date={order.createdAt}
           items={order.products}
           status={order.status}
           deliveredAt={order.deliveredAt}
           clickOnReviewListener={handleOnClickItemReview}
           clickOnQuestionListener={handleOnClickItemQuestion}
+          clickOnDeliveryListener={handleOnClieItemDelivery(order.id)}
         />
       </S.OrderHistoryBody>
     ));
@@ -112,6 +123,7 @@ const OrderHistory = ({}) => {
       <Pagination
         handleOnClickPage={handleOnClickPage}
         count={Math.ceil(orders.length / PAGE_LIMIT)}
+        offset={offset}
       />
 
       {isOpenReviewModal && (
@@ -121,6 +133,12 @@ const OrderHistory = ({}) => {
         <RequestModal
           selected={selectedQuestion}
           toggleModal={toggleQuestionModal}
+        />
+      )}
+      {isOpenDeliveryModal && (
+        <DeliveryModal
+          selectedOrderId={selectedOrderId}
+          toggleModal={toggleDeliveryModal}
         />
       )}
     </S.OrerHistory>

--- a/client/src/components/MyPage/OrderHistory/OrderItemList/OrderItemList.tsx
+++ b/client/src/components/MyPage/OrderHistory/OrderItemList/OrderItemList.tsx
@@ -4,13 +4,11 @@ import { wonFormat, dateFormat } from '@/utils/helper';
 import { ORDER_STATUS } from '@/contstants';
 import { Link } from '@/lib/Router';
 import useModal from '@/hooks/useModal';
-import DeliveryModal from '@/components/Shared/Modal/DeliveryModal';
 
 interface IProps {
   date: string;
   status: string;
   deliveredAt?: string | Date;
-  orderId: number;
   items: {
     id: number;
     title: string;
@@ -20,6 +18,7 @@ interface IProps {
   }[];
   clickOnReviewListener: (target: number) => void;
   clickOnQuestionListener: (target: number) => void;
+  clickOnDeliveryListener: () => void;
 }
 
 const OrderItemList = ({
@@ -29,9 +28,8 @@ const OrderItemList = ({
   deliveredAt,
   clickOnReviewListener,
   clickOnQuestionListener,
-  orderId,
+  clickOnDeliveryListener,
 }: IProps) => {
-  const [openModal, toggleModal] = useModal(false);
   return (
     <div>
       <S.OrderItemListHeader>
@@ -53,7 +51,7 @@ const OrderItemList = ({
               <S.OrderDeliveryButton
                 type="button"
                 color="white"
-                onClick={toggleModal}
+                onClick={clickOnDeliveryListener}
               >
                 배송조회
               </S.OrderDeliveryButton>
@@ -101,7 +99,6 @@ const OrderItemList = ({
           </S.OrderItem>
         ))}
       </S.OrderItemList>
-      {openModal && <DeliveryModal id={orderId} toggleModal={toggleModal} />}
     </div>
   );
 };

--- a/client/src/components/MyPage/OrderHistory/OrderItemList/styles.ts
+++ b/client/src/components/MyPage/OrderHistory/OrderItemList/styles.ts
@@ -20,6 +20,8 @@ export const OrderItemInfo = styled.div`
   flex: 3;
   padding: 2rem;
   border-right: 1px solid ${({ theme }) => theme.color['border-gray']};
+  display: flex;
+  align-items: center;
 `;
 
 export const OrderItemInfoHeader = styled.header`
@@ -47,7 +49,6 @@ export const OrderItemInfoSubStatus = styled.span`
 `;
 
 export const OrderItemInfoBody = styled.div`
-  margin-top: 2.4rem;
   display: flex;
 `;
 
@@ -61,12 +62,18 @@ export const OrderItemInfoDescription = styled.section`
 export const OrderItemName = styled.span`
   ${({ theme }) => theme.fontWeight.xl};
   ${({ theme }) => theme.fontSize.l};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 `;
 
 export const OrderItemPrice = styled.span`
   ${({ theme }) => theme.fontWeight.m};
   ${({ theme }) => theme.fontSize.m};
   color: ${({ theme }) => theme.color.label};
+  padding-top: 0.8rem;
 `;
 
 export const OrderItemActions = styled.div`

--- a/client/src/components/Shared/Modal/DeliveryModal/DeliveryModal.tsx
+++ b/client/src/components/Shared/Modal/DeliveryModal/DeliveryModal.tsx
@@ -8,9 +8,9 @@ import { useQueryClient } from 'react-query';
 
 interface IProps {
   toggleModal: () => void;
-  id: number;
+  selectedOrderId: number;
 }
-const DeliveryModal = ({ toggleModal, id }: IProps) => {
+const DeliveryModal = ({ toggleModal, selectedOrderId }: IProps) => {
   const [imgeLoaded, setImgeLoaded] = useState(false);
   const [delivered, setDelivered] = useState(false);
   const { mutate, isLoading } = useUpdateOrder();
@@ -22,7 +22,7 @@ const DeliveryModal = ({ toggleModal, id }: IProps) => {
         mutate(
           {
             order: {
-              id,
+              id: selectedOrderId,
               status: 'delivered',
               deliveredAt: new Date(),
             },
@@ -36,7 +36,7 @@ const DeliveryModal = ({ toggleModal, id }: IProps) => {
         );
       }, 3000);
     }
-  }, [imgeLoaded, mutate, id, queryClient]);
+  }, [imgeLoaded, mutate, selectedOrderId, queryClient]);
 
   return (
     <ModalLayout width="32rem" height="30rem" toggleModal={toggleModal}>

--- a/client/src/components/Shared/Pagination/Pagination.tsx
+++ b/client/src/components/Shared/Pagination/Pagination.tsx
@@ -1,15 +1,22 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { nanoid } from 'nanoid';
 import * as S from './styles';
 
 interface IPagination {
   count: number;
   handleOnClickPage: (idx: number) => void;
+  offset?: number;
 }
 
-const Pagination = ({ count, handleOnClickPage }: IPagination) => {
+const Pagination = ({ count, handleOnClickPage, offset }: IPagination) => {
   const pages = new Array(count).fill('');
   const [selected, setSelected] = useState(0);
+
+  useEffect(() => {
+    if (offset === 0) {
+      setSelected(0);
+    }
+  }, [offset]);
 
   const handleOnClick = (e: React.MouseEvent) => {
     const target = e.target as HTMLDivElement;

--- a/client/src/styles/globalStyle.ts
+++ b/client/src/styles/globalStyle.ts
@@ -52,8 +52,6 @@ export const media = {
   btw_tab_mob: BTW_TAB_AND_MOBILE_RESOLUTION,
   phone: PHONE_RESOLUTION,
   headerSearch: HEADER_SEARCH_RESOLUTION,
-  btw_pc_tab: BTW_PC_AND_TAB_RESOLUTION,
-  btw_tab_mob: BTW_TAB_AND_MOBILE_RESOLUTION,
 };
 
 const GlobalStyle = createGlobalStyle`

--- a/client/src/styles/styled.d.ts
+++ b/client/src/styles/styled.d.ts
@@ -47,8 +47,6 @@ declare module 'styled-components' {
       btw_tab_mob: number;
       phone: number;
       headerSearch: number;
-      btw_pc_tab: number;
-      btw_tab_mob: number;
     };
     mediaScreen: {
       pc: (args: TemplateStringsArray) => FlattenSimpleInterpolation;


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->
- 배송 조회시에 페이지네이션, 모달 자동 닫힘 문제 처리합니다
- 페이지네이션 컴포넌트 리셋하는 방법이 없어서 offset으로 임시 처리했어요! 페이지네이션 훅스에 page 추가해서 페이지네이션 컴포넌트로 내릴까하다가 코드 너무 많이 바꾸는 거 같아서 우선은 요렇게 마무리 지었습니다.

## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 ex. #10 -->

closes #316 

## 추가 구현 필요사항

## 스크린샷

- Storybook 리뷰/테스트 참고
